### PR TITLE
Don't crash on missing addresses - just print them and go on

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ pub fn analyze_executable(elf: &[u8]) -> Result<Functions<'_>, failure::Error> {
             } else if let Some(sym) = defined.get_mut(&(address & !1)) {
                 sym.stack = Some(stack);
             } else {
-                unreachable!()
+                eprintln!("Address {:?} not found", address);
             }
         }
     }


### PR DESCRIPTION
This allows stack-sizes to work on binaries where previously it was crashing.