### PR TITLE
API change from &str to String, etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "stack-sizes"
 readme = "README.md"
 repository = "https://github.com/japaric/stack-sizes"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
Changes made to work with the new version of `cargo-call-stack`.
Now values are cloned a lot more instead of borrowing.